### PR TITLE
Upgrade to Cabal 2.0

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -5,9 +5,9 @@ import Data.Encoding.Preprocessor.Mapping
 import Data.Encoding.Preprocessor.XMLMappingBuilder
 
 main = defaultMainWithHooks (simpleUserHooks
-                             {hookedPreProcessors = (("mapping",\_ _ -> mappingPreprocessor)
-                                                     :("mapping2",\_ _ -> mappingPreprocessor)
-                                                     :("xml",\_ _ -> xmlPreprocessor)
+                             {hookedPreProcessors = (("mapping",\_ _ _ -> mappingPreprocessor)
+                                                     :("mapping2",\_ _ _ -> mappingPreprocessor)
+                                                     :("xml",\_ _ _ -> xmlPreprocessor)
                                                      :(hookedPreProcessors simpleUserHooks)
                                                     )
                              })

--- a/encoding.cabal
+++ b/encoding.cabal
@@ -36,7 +36,7 @@ Source-Repository this
 
 Custom-Setup
   Setup-Depends: base >=3 && <5,
-                 Cabal >=1.24 && <1.25,
+                 Cabal >= 2.0,
                  containers,
                  filepath,
                  ghc-prim,

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-8.22
+resolver: lts-13.0
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -39,7 +39,10 @@ packages:
 - '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+- HaXml-1.25.5
+- containers-0.5.11.0
+- regex-compat-0.93.1
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
During development of [hsexif](https://github.com/emmanueltouzery/hsexif/pull/16#issuecomment-449999232) I have discovered that the `encoding` package does not compatible with modern `stack` because of the dependency on Cabal-1.24 for the custom `Setup.hs`.