### PR TITLE
Fix autogen modules list, adopt to upgraded Hackage

### DIFF
--- a/System/IO/Encoding.hs
+++ b/System/IO/Encoding.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE ImplicitParams,ForeignFunctionInterface #-}
+{-# LANGUAGE CPP                      #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE ImplicitParams           #-}
 {- | This module provides a replacement for the normal (unicode unaware) IO functions of haskell.
      By using implicit parameters, it can be used almost as a drop-in replacement.
      For example, consider the following simple echo program:
@@ -31,7 +33,7 @@
      >   e <- getSystemEncoding
      >   let ?enc = e
      >   str <- getContents
-     >   putStr str     
+     >   putStr str
  -}
 module System.IO.Encoding
     (getSystemEncoding
@@ -54,14 +56,16 @@ module System.IO.Encoding
     ,print
     ,hPrint) where
 
-import Foreign.C.String
+import           Foreign.C.String
 
-import Data.Encoding
-import System.IO (Handle,stdout,stdin)
-import Prelude hiding (print,getContents,readFile,writeFile,appendFile,interact,putStr,putStrLn,getChar,getLine,putChar)
+import           Control.Monad.Reader (runReaderT)
+import qualified Data.ByteString      as BS
 import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString as BS
-import Control.Monad.Reader (runReaderT)
+import           Data.Encoding
+import           Prelude              hiding (appendFile, getChar, getContents,
+                                       getLine, interact, print, putChar,
+                                       putStr, putStrLn, readFile, writeFile)
+import           System.IO            (Handle, stdin, stdout)
 
 -- | Like the normal 'System.IO.hGetContents', but decodes the input using an
 --   encoding.

--- a/encoding.cabal
+++ b/encoding.cabal
@@ -9,7 +9,7 @@ Description:
   Haskell has excellect handling of unicode, the Char type covers all unicode chars. Unfortunately, there's no possibility to read or write something to the outer world in an encoding other than ascii due to the lack of support for encodings. This library should help with that.
 Category:	Codec
 Homepage:	http://code.haskell.org/encoding/
-Cabal-Version:	>=1.8
+Cabal-Version:	>=1.10
 Build-Type:	Custom
 Extra-Source-Files:
   CHANGELOG
@@ -53,7 +53,7 @@ Library
                  mtl >=2.0 && <2.3,
                  regex-compat >=0.71 && <0.95
 
-  Extensions: CPP
+  Default-Language: Haskell2010
 
   Exposed-Modules:
     Data.Encoding
@@ -125,7 +125,6 @@ Library
     Data.Static
     Data.CharMap
   Autogen-Modules:
-    Data.Encoding.ISO88591
     Data.Encoding.ISO88592
     Data.Encoding.ISO88593
     Data.Encoding.ISO88594
@@ -195,3 +194,4 @@ test-suite encoding-test
                      , HUnit
                      , QuickCheck
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  Default-Language:  Haskell2010


### PR DESCRIPTION
Fixes issue #8. 

- Fixes builds with Cabal 2.0.
- Fixes warnings from Hackage (Cabal 3.0).
- Explicitly added CPP pragma to `System.IO.Encoding` instead of cabal extensions. 