### PR TITLE
Data/Map/Static/Builder.hs: avoid shiftL with negative offset

### DIFF
--- a/Data/Map/Static/Builder.hs
+++ b/Data/Map/Static/Builder.hs
@@ -37,6 +37,6 @@ treeDepth sz = find' [0..]
 findSplitSize :: Int -> Int
 findSplitSize len = let depth = treeDepth len
                         free = (maxSize depth) - len
-                    in if free <= (1 `shiftL` (depth - 2))
+                    in if 2 * free <= (1 `shiftL` (depth - 1))
                        then maxSize (depth - 1)
                        else len - (maxSize (depth - 2)) - 1


### PR DESCRIPTION
On ghc-8.8 building `encoding` fails as:

```
Preprocessing library for encoding-0.8.5..
arithmetic overflow
```

This happens because `findSplitSize` can't handle
small values, like `findSplitSize 1` and calls `shiftL`
with negative value, which is forbdden:
    https://hackage.haskell.org/package/base-4.14.0.0/docs/Data-Bits.html#v:shiftL

Work it around by always passing non-negative offset.