### PR TITLE
Add GHC 9 build support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,8 @@
+packages: .
+
+-- FIXME: remove after release HaXml-1.25.6
+source-repository-package
+    type: git
+    location: https://github.com/hackage-trustees/malcolm-wallace-universe
+    subdir: HaXml-1.25.4
+    branch: master

--- a/encoding.cabal
+++ b/encoding.cabal
@@ -43,7 +43,7 @@ Custom-Setup
                  containers,
                  filepath,
                  ghc-prim,
-                 HaXml >=1.22 && <1.26
+                 HaXml >=1.22 && <1.27
 
 Library
   Build-Depends: array >=0.4 && <0.6,
@@ -52,9 +52,9 @@ Library
                  bytestring >=0.9 && <0.11,
                  containers >=0.4 && <0.7,
                  extensible-exceptions >=0.1 && <0.2,
-                 ghc-prim >=0.3 && <0.7,
+                 ghc-prim >=0.3 && <0.8,
                  mtl >=2.0 && <2.3,
-                 regex-compat >=0.71 && <0.95
+                 regex-compat >=0.71 && <0.96
 
   Default-Language: Haskell2010
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,6 +17,9 @@
 #  location: "./custom-snapshot.yaml"
 resolver: lts-13.0
 
+extra-deps:
+  - HaXml-1.25.5
+
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #


### PR DESCRIPTION
- Add GHC 9 support (temporary repoint `HaXml-1.25.5` location).
- Relax boundaries for dependencies.