### PR TITLE
Support Cabal-3.8.1 + GHC 9.2 and 9.4

### DIFF
--- a/Data/Encoding/Preprocessor/Mapping.hs
+++ b/Data/Encoding/Preprocessor/Mapping.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Data.Encoding.Preprocessor.Mapping where
 
 import Distribution.Simple.PreProcess
@@ -69,6 +70,10 @@ validTranslations = mapMaybe (\(n,mc) -> case mc of
 mappingPreprocessor :: PreProcessor
 mappingPreprocessor = PreProcessor
                   {platformIndependent = True
+#if MIN_VERSION_Cabal(3,8,0)
+                  ,ppOrdering=unsorted
+#endif
+
                   ,runPreProcessor = \(sbase,sfile) (tbase,tfile) verb -> do
                                        let (dir,fn) = splitFileName sfile
                                        let (bname,ext) = splitExtensions fn

--- a/Data/Encoding/Preprocessor/XMLMappingBuilder.hs
+++ b/Data/Encoding/Preprocessor/XMLMappingBuilder.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ParallelListComp #-}
+{-# LANGUAGE ParallelListComp, CPP #-}
 module Data.Encoding.Preprocessor.XMLMappingBuilder where
 
 import Data.Word
@@ -19,6 +19,9 @@ import Control.Exception (assert)
 xmlPreprocessor :: PreProcessor
 xmlPreprocessor = PreProcessor
                   { platformIndependent = True
+#if MIN_VERSION_Cabal(3,8,0)
+                  , ppOrdering=unsorted
+#endif
                   , runPreProcessor = \src trg verb -> do
                                         createModuleFromFile src trg
                   }

--- a/encoding.cabal
+++ b/encoding.cabal
@@ -44,10 +44,10 @@ Library
   Build-Depends: array >=0.4 && <0.6,
                  base >=4 && <5,
                  binary >=0.7 && <0.10,
-                 bytestring >=0.9 && <0.11,
+                 bytestring >=0.9 && <0.12,
                  containers >=0.4 && <0.7,
                  extensible-exceptions >=0.1 && <0.2,
-                 ghc-prim >=0.3 && <0.8,
+                 ghc-prim >=0.3 && <0.10,
                  mtl >=2.0 && <2.3,
                  regex-compat >=0.71 && <0.96
 


### PR DESCRIPTION
Builds with:
Cabal 3.6.2.0 + GHC 8.10.7
Cabal 3.6.2.0 + GHC 9.2.4
Cabal 3.8.1 + GHC 8.10.7
Cabal 3.8.1 + GHC 9.2.4
Cabal 3.8.1 + GHC 9.4.2

Requires performance review and to be tested (`cabal test` passes with ghc 9.4.2 and Cabal 3.8.1)