### PR TITLE
Support upcoming cabal 3.12 preprocessor breaking change

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Main where
 
 import Distribution.Simple


### PR DESCRIPTION
There are a breaking change merged into Cabal upstream repository which would be a part of upcoming Cabal 3.12 release

`hookedPreProcessors` part of preprocessor API part has type [PPSuffixHandler]. Which is changed by [65905b9 commit](https://github.com/haskell/cabal/commit/65905b980e5c79362cfe62416720aee3f78e5628#diff-7bf52f59066d048286852f159107d4da28d30bb997310f2480bed80a5e9150b8L189-R130) by replacing raw String with Suffix newtype which has IsString instance so we can just enable OverloadedStrings to make our preprocessor code compatible with current preprocessor API and upcoming breaking change
