### PR TITLE
Bump `containers` version

### DIFF
--- a/encoding.cabal
+++ b/encoding.cabal
@@ -45,7 +45,7 @@ Library
                  base >=4 && <5,
                  binary >=0.7 && <0.10,
                  bytestring >=0.9 && <0.13,
-                 containers >=0.4 && <0.7,
+                 containers >=0.4 && <0.8,
                  extensible-exceptions >=0.1 && <0.2,
                  ghc-prim >=0.3 && <0.12,
                  mtl >=2.0 && <2.4,


### PR DESCRIPTION
Closes #21. 