### PR TITLE
Add contributing doc, readme and describe the process

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Did you find a bug?
+
+- Please create a new issue with description.
+- It would be nice if you provide more details such as GHC version, cabal-install version (or other build tool title and version).
+- Reproducible case will be appreciated.
+
+# Do you want to add a new or missing encoding?
+
+1. Add file to repo (see `.mapping` or `.xml` files in `./Data/Encoding`.
+2. Install encoding generator via `cabal install -fgenerate-encodings encoding-exe`.
+3. Run encoding generator with your newly added files.
+4. List generated modules in `encoding.cabal` and commit file.
+5. Ensure the package could be built.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# encoding
+
+Haskell has excellect handling of unicode, the Char type covers all unicode chars. Unfortunately, there's no possibility to read or write something to the outer world in an encoding other than ascii due to the lack of support for encodings. This library should help with that.
+
+## Contributions
+
+See [CONTRIBUTING.md](https://github.com/dmwit/encoding/blob/master/.github/CONTRIBUTING.md) for more details.

--- a/encoding.cabal
+++ b/encoding.cabal
@@ -1,18 +1,20 @@
 Name:		encoding
 Version:	0.8.10
 Author:		Henning Günther
-Maintainer:	daniel@wagner-home.com
+Maintainer:	daniel@wagner-home.com, Andrey Prokopenko
 License:	BSD3
 License-File:   LICENSE
 Synopsis:	A library for various character encodings
 Description:
   Haskell has excellect handling of unicode, the Char type covers all unicode chars. Unfortunately, there's no possibility to read or write something to the outer world in an encoding other than ascii due to the lack of support for encodings. This library should help with that.
 Category:	Codec
-Homepage:	http://code.haskell.org/encoding/
+Homepage:	https://github.com/dmwit/encoding
+Bug-Reports:    https://github.com/dmwit/encoding/issues
 Cabal-Version:	2.0
 Build-Type:	Simple
 Extra-Source-Files:
   CHANGELOG
+  README.md
   system_encoding.h
   system_encoding.c
 


### PR DESCRIPTION
Since #24, the process has been changed. Instead of on-flight auto-generation we start providing static modules which could be built much faster. It comes with a cost of extra process. To reduce bus-factor I am adding
- simple CONTRIBUTING guideline which describes how to add more encodings to the package behind the scenes. 
- README (for better visibility both here and on Hackage) with a link to this new contribution guideline.
- Update cabal with README.

I believe, for now it should be enough. With that, package is almost ready for release.