### PR TITLE
Provide the getSystemEncoding function always, improving portability (#26)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Provide the getSystemEncoding function always, improving portability (#26).
+  - The getSystemEncoding function is now present on all platforms.
+  - It now returns Nothing if there is an error, or if running on Windows.
+  - The systemEncoding flag has been dropped.
+
 Changes from 0.8.10 to 0.9
 ---------------------------
 

--- a/System/IO/Encoding.hs
+++ b/System/IO/Encoding.hs
@@ -135,19 +135,19 @@ interact f = do
   line <- hGetLine stdin
   hPutStrLn stdout (f line)
 
-#ifdef SYSTEM_ENCODING
+#ifndef mingw32_HOST_OS
 foreign import ccall "system_encoding.h get_system_encoding"
 	get_system_encoding :: IO CString
 #endif
 
--- | Returns the encoding used on the current system. Currently only supported
--- on Linux-alikes.
-getSystemEncoding :: IO DynEncoding
+-- | On unix machines, returns the system's currently configured text encoding,
+-- or Nothing if there was an error. On Windows, currently always returns Nothing.
+getSystemEncoding :: IO (Maybe DynEncoding)
 getSystemEncoding = do
-#ifdef SYSTEM_ENCODING
-	enc <- get_system_encoding
-	str <- peekCString enc
-	return $ encodingFromString str
+#ifndef mingw32_HOST_OS
+  enc <- get_system_encoding
+  str <- peekCString enc
+  return $ encodingFromStringExplicit str
 #else
-	error "getSystemEncoding is not supported on this platform"
+  return Nothing
 #endif

--- a/encoding.cabal
+++ b/encoding.cabal
@@ -18,9 +18,6 @@ Extra-Source-Files:
   system_encoding.h
   system_encoding.c
 
-Flag systemEncoding
-  description: Provide the getSystemEncoding action to query the locale.
-
 Flag generate-encodings
   description: Generate encodings.
   manual: True
@@ -114,14 +111,13 @@ Library
     Data.CharMap
   if impl(ghc >= 7.10)
     GHC-Options: -fno-warn-tabs
-  if flag(systemEncoding)
+  if !os(windows)
     Includes:
       system_encoding.h
     Install-Includes:
       system_encoding.h
     C-Sources:
       system_encoding.c
-    CPP-Options: -DSYSTEM_ENCODING
 
 executable encoding-exe
   main-is: Main.hs


### PR DESCRIPTION
This attempts to simplify the API and resolve #26 (windows build failures).
