### PR TITLE
Relax ghc-prim boundary to allow 0.12

### DIFF
--- a/encoding.cabal
+++ b/encoding.cabal
@@ -34,7 +34,7 @@ Library
                  bytestring >=0.9 && <0.13,
                  containers >=0.4 && <0.8,
                  extensible-exceptions >=0.1 && <0.2,
-                 ghc-prim >=0.3 && <0.12,
+                 ghc-prim >=0.3 && <0.13,
                  mtl >=2.0 && <2.4,
                  regex-compat >=0.71 && <0.96
 


### PR DESCRIPTION
Closes #29.

Preparation for support of 9.10.2 (stackage).