### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/Control/Throws.hs
+++ b/Control/Throws.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleInstances,MultiParamTypeClasses #-}
 module Control.Throws where
 
-import Control.Exception.Extensible
+import Control.Exception
 import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.State

--- a/Data/Encoding/ByteSink.hs
+++ b/Data/Encoding/ByteSink.hs
@@ -10,7 +10,7 @@ import Data.Sequence
 import Data.Word
 import Data.Foldable (toList)
 import Control.Throws
-import Control.Exception.Extensible
+import Control.Exception
 import Control.Applicative
 import Control.Monad (ap, liftM)
 import Control.Monad.IO.Class (liftIO)

--- a/Data/Encoding/ByteSource.hs
+++ b/Data/Encoding/ByteSource.hs
@@ -14,7 +14,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.State (StateT (..), get, gets, put)
 import Control.Monad.Identity (Identity)
 import Control.Monad.Reader (ReaderT, ask)
-import Control.Exception.Extensible
+import Control.Exception
 import Control.Throws
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS

--- a/Data/Encoding/Exception.hs
+++ b/Data/Encoding/Exception.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module Data.Encoding.Exception where
 
-import Control.Exception.Extensible
+import Control.Exception
 import Data.Word
 import Data.Typeable
 import Control.Monad.Identity

--- a/Data/Static.hs
+++ b/Data/Static.hs
@@ -2,7 +2,6 @@
 module Data.Static where
 
 import GHC.Exts
-import GHC.Prim
 import GHC.Word
 import Data.Word
 import Data.Bits

--- a/encoding.cabal
+++ b/encoding.cabal
@@ -33,7 +33,6 @@ Library
                  binary >=0.7 && <0.10,
                  bytestring >=0.9 && <0.13,
                  containers >=0.4 && <0.8,
-                 ghc-prim >=0.3 && <0.14,
                  mtl >=2.0 && <2.4,
                  regex-compat >=0.71 && <0.96
 

--- a/encoding.cabal
+++ b/encoding.cabal
@@ -33,7 +33,6 @@ Library
                  binary >=0.7 && <0.10,
                  bytestring >=0.9 && <0.13,
                  containers >=0.4 && <0.8,
-                 extensible-exceptions >=0.1 && <0.2,
                  ghc-prim >=0.3 && <0.14,
                  mtl >=2.0 && <2.4,
                  regex-compat >=0.71 && <0.96


### PR DESCRIPTION
For `base >= 4`, `extensible-exceptions` simply reexports `Control.Exception`. The functions used from `GHC.Prim` are also available from `GHC.Exts`. It is also not recommended to depend on `ghc-prim`.